### PR TITLE
CDR Launch Scope Implementation and Setup Simplification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mvn -B clean package -DskipTests
 
 
 # Package stage
-FROM quay.io/keycloak/keycloak:18.0.2
+FROM quay.io/keycloak/keycloak:25.0.5
 
 # This can be overridden, but without this I've found the db vendor-detection in Keycloak to be brittle
 ENV KC_HEALTH_ENABLED=true

--- a/keycloak-config/src/main/java/org/alvearie/keycloak/config/KeycloakConfigurator.java
+++ b/keycloak-config/src/main/java/org/alvearie/keycloak/config/KeycloakConfigurator.java
@@ -41,6 +41,7 @@ import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.userprofile.config.UPAttribute;
 import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.representations.userprofile.config.UPConfig.UnmanagedAttributePolicy;
 
@@ -82,6 +83,13 @@ public class KeycloakConfigurator {
 			System.out.println("setting unmanagedAttributePolicy: " + unmanagedAttributePolicy);
 			UPConfig upConfig = realms.realm(realmName).users().userProfile().getConfiguration();
 			upConfig.setUnmanagedAttributePolicy(UnmanagedAttributePolicy.valueOf(unmanagedAttributePolicy));
+			// Turn additional user profile attributes optional to remove the user profile setup page from test
+			for (String attrName : new String[]{"email", "firstName", "lastName"}) {
+				UPAttribute attr = upConfig.getAttribute(attrName);
+				if (attr != null) {
+					attr.setRequired(null);
+				}
+			}
 			realms.realm(realmName).users().userProfile().update(upConfig);
 		}
 
@@ -930,10 +938,18 @@ public class KeycloakConfigurator {
 		if (user == null) {
 			user = new UserRepresentation();
 			user.setUsername(userName);
-			users.create(user);
+			Response createResponse = users.create(user);
+			int status = createResponse.getStatus();
+			if (status < 200 || status >= 300) {
+				String errorBody = "";
+				try { errorBody = createResponse.readEntity(String.class); } catch (Exception ignored) {}
+				createResponse.close();
+				throw new RuntimeException("Unable to create user '" + userName + "': HTTP " + status + " " + errorBody);
+			}
+			createResponse.close();
 			user = getUserByName(users, userName);
 			if (user == null) {
-				throw new RuntimeException("Unable to create user");
+				throw new RuntimeException("Unable to create user '" + userName + "': user not found after creation");
 			}
 		}
 

--- a/keycloak-config/src/main/java/org/alvearie/keycloak/config/KeycloakConfigurator.java
+++ b/keycloak-config/src/main/java/org/alvearie/keycloak/config/KeycloakConfigurator.java
@@ -41,6 +41,8 @@ import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.userprofile.config.UPConfig;
+import org.keycloak.representations.userprofile.config.UPConfig.UnmanagedAttributePolicy;
 
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
@@ -72,6 +74,15 @@ public class KeycloakConfigurator {
 			if (realm == null) {
 				throw new RuntimeException("Unable to create realm");
 			}
+		}
+
+		// Update User Profile configuration (unmanaged attribute policy)
+		String unmanagedAttributePolicy = realmPg.getStringProperty(KeycloakConfig.PROP_UNMANAGED_ATTRIBUTE_POLICY);
+		if (unmanagedAttributePolicy != null) {
+			System.out.println("setting unmanagedAttributePolicy: " + unmanagedAttributePolicy);
+			UPConfig upConfig = realms.realm(realmName).users().userProfile().getConfiguration();
+			upConfig.setUnmanagedAttributePolicy(UnmanagedAttributePolicy.valueOf(unmanagedAttributePolicy));
+			realms.realm(realmName).users().userProfile().update(upConfig);
 		}
 
 		// Initialize client scopes
@@ -1018,8 +1029,6 @@ public class KeycloakConfigurator {
 
 	/**
 	 * Gets the client by client ID.
-	 * @param adminClient the clients
-	 * @param clientName the client name
 	 * @return the client, or null if not found
 	 */
 	private ClientRepresentation getClientByClientId(ClientsResource clients, String clientId) {
@@ -1063,7 +1072,6 @@ public class KeycloakConfigurator {
 
 	/**
 	 * Gets the identity provider mapper by name.
-	 * @param identity provider the identity provider
 	 * @param mapperName the mapper name
 	 * @return the identity provider mapper, or null if not found
 	 */

--- a/keycloak-config/src/main/java/org/alvearie/keycloak/config/util/KeycloakConfig.java
+++ b/keycloak-config/src/main/java/org/alvearie/keycloak/config/util/KeycloakConfig.java
@@ -102,6 +102,7 @@ public class KeycloakConfig {
 	public static final String PROP_EVENTS_CONFIG_EXPIRATION = "expiration";
 	public static final String PROP_EVENTS_CONFIG_SAVE_TYPES = "types";
 	public static final String PROP_EVENTS_CONFIG_SAVE_ADMIN_EVENTS = "saveAdminEvents";
+	public static final String PROP_UNMANAGED_ATTRIBUTE_POLICY = "unmanagedAttributePolicy";
 
 	private static final JsonReaderFactory JSON_READER_FACTORY = Json.createReaderFactory(null);
 
@@ -204,9 +205,6 @@ public class KeycloakConfig {
 	/**
 	 * Loads the specified file as a JSON file and returns a PropertyGroup containing the contents of the JSON file as
 	 * the root property group.
-	 *
-	 * @param filename
-	 *            the name of the JSON file to be loaded
 	 */
 	private PropertyGroup loadConfiguration() {
 		if (config == null) {

--- a/keycloak-config/src/main/resources/config/backend-services-config.json
+++ b/keycloak-config/src/main/resources/config/backend-services-config.json
@@ -42,7 +42,7 @@
 								"protocolmapper": "oidc-usermodel-attribute-mapper",
 								"config": {
 									"user.attribute": "relatedPatients",
-									"claim.name": "patient_id",
+									"claim.name": "patient",
 									"jsonType.label": "String",
 									"id.token.claim": "false",
 									"access.token.claim": "true",
@@ -53,7 +53,7 @@
 								"protocol": "openid-connect",
 								"protocolmapper": "oidc-usersessionmodel-note-mapper",
 								"config": {
-									"user.session.note": "patient_id",
+									"user.session.note": "patient",
 									"claim.name": "patient",
 									"jsonType.label": "String",
 									"id.token.claim": "false",

--- a/keycloak-config/src/main/resources/config/backend-services-config.json
+++ b/keycloak-config/src/main/resources/config/backend-services-config.json
@@ -7,6 +7,7 @@
 		"realms": {
 			"${KEYCLOAK_REALM}": {
 				"enabled": true,
+				"unmanagedAttributePolicy": "ENABLED",
 				"clientScopes": {
 					"fhirUser": {
 						"protocol": "openid-connect",
@@ -19,7 +20,7 @@
 								"protocol": "openid-connect",
 								"protocolmapper": "oidc-patient-prefix-usermodel-attribute-mapper",
 								"config": {
-									"user.attribute": "resourceId",
+									"user.attribute": "relatedPatients",
 									"claim.name": "fhirUser",
 									"jsonType.label": "String",
 									"id.token.claim": "true",
@@ -40,7 +41,7 @@
 								"protocol": "openid-connect",
 								"protocolmapper": "oidc-usermodel-attribute-mapper",
 								"config": {
-									"user.attribute": "resourceId",
+									"user.attribute": "relatedPatients",
 									"claim.name": "patient_id",
 									"jsonType.label": "String",
 									"id.token.claim": "false",
@@ -1483,7 +1484,7 @@
 						"password": "change-password",
 						"passwordTemporary": false,
 						"attributes": {
-							"resourceId": ["Patient1"]
+							"relatedPatients": ["Patient1"]
 						},
 						"groups": ["fhirUser"]
 					}

--- a/keycloak-config/src/main/resources/config/keycloak-config-with-idp.json
+++ b/keycloak-config/src/main/resources/config/keycloak-config-with-idp.json
@@ -37,16 +37,28 @@
 							"display.on.consent.screen": "false"
 						},
 						"mappers": {
-							"Patient ID Mapper": {
+							"Patient ID Claim Mapper": {
 								"protocol": "openid-connect",
 								"protocolmapper": "oidc-usermodel-attribute-mapper",
 								"config": {
 									"user.attribute": "relatedPatients",
 									"jsonType.label": "String",
-									"claim.name": "patient_id",
+									"claim.name": "patient",
 									"id.token.claim": "false",
 									"access.token.claim": "true",
 									"userinfo.token.claim": "false"
+								}
+							},
+							"Patient ID Token Mapper": {
+								"protocol": "openid-connect",
+								"protocolmapper": "oidc-usersessionmodel-note-mapper",
+								"config": {
+									"user.session.note": "patient",
+									"claim.name": "patient",
+									"jsonType.label": "String",
+									"id.token.claim": "false",
+									"access.token.claim": "false",
+									"access.tokenResponse.claim": "true"
 								}
 							},
 							"Group Membership Mapper": {

--- a/keycloak-config/src/main/resources/config/keycloak-config-with-idp.json
+++ b/keycloak-config/src/main/resources/config/keycloak-config-with-idp.json
@@ -7,6 +7,7 @@
 		"realms": {
 			"${KEYCLOAK_REALM}": {
 				"enabled": true,
+				"unmanagedAttributePolicy": "ENABLED",
 				"clientScopes": {
 					"fhirUser": {
 						"protocol": "openid-connect",
@@ -19,7 +20,7 @@
 								"protocol": "openid-connect",
 								"protocolmapper": "oidc-patient-prefix-usermodel-attribute-mapper",
 								"config": {
-									"user.attribute": "resourceId",
+									"user.attribute": "relatedPatients",
 									"claim.name": "fhirUser",
 									"jsonType.label": "String",
 									"id.token.claim": "true",
@@ -40,7 +41,7 @@
 								"protocol": "openid-connect",
 								"protocolmapper": "oidc-usermodel-attribute-mapper",
 								"config": {
-									"user.attribute": "resourceId",
+									"user.attribute": "relatedPatients",
 									"jsonType.label": "String",
 									"claim.name": "patient_id",
 									"id.token.claim": "false",
@@ -581,12 +582,12 @@
 									"user.attribute": "userId"
 								}
 							},
-							"Import resourceId": {
+							"Import relatedPatients": {
 								"identityProviderMapper": "oidc-user-attribute-idp-mapper",
 								"config": {
 									"syncMode": "INHERIT",
-									"claim": "${IDENTITY_PROVIDER_RESOURCEID_CLAIM}",
-									"user.attribute": "resourceId"
+									"claim": "${IDENTITY_PROVIDER_relatedPatients_CLAIM}",
+									"user.attribute": "relatedPatients"
 								}
 							}
 						}

--- a/keycloak-config/src/main/resources/config/keycloak-config.json
+++ b/keycloak-config/src/main/resources/config/keycloak-config.json
@@ -42,7 +42,7 @@
 								"protocolmapper": "oidc-usermodel-attribute-mapper",
 								"config": {
 									"user.attribute": "relatedPatients",
-									"claim.name": "patient_id",
+									"claim.name": "patient",
 									"jsonType.label": "String",
 									"id.token.claim": "false",
 									"access.token.claim": "true",
@@ -53,7 +53,7 @@
 								"protocol": "openid-connect",
 								"protocolmapper": "oidc-usersessionmodel-note-mapper",
 								"config": {
-									"user.session.note": "patient_id",
+									"user.session.note": "patient",
 									"claim.name": "patient",
 									"jsonType.label": "String",
 									"id.token.claim": "false",

--- a/keycloak-config/src/main/resources/config/keycloak-config.json
+++ b/keycloak-config/src/main/resources/config/keycloak-config.json
@@ -7,6 +7,7 @@
 		"realms": {
 			"${KEYCLOAK_REALM}": {
 				"enabled": true,
+				"unmanagedAttributePolicy": "ENABLED",
 				"clientScopes": {
 					"fhirUser": {
 						"protocol": "openid-connect",
@@ -19,7 +20,7 @@
 								"protocol": "openid-connect",
 								"protocolmapper": "oidc-patient-prefix-usermodel-attribute-mapper",
 								"config": {
-									"user.attribute": "resourceId",
+									"user.attribute": "relatedPatients",
 									"claim.name": "fhirUser",
 									"jsonType.label": "String",
 									"id.token.claim": "true",
@@ -40,7 +41,7 @@
 								"protocol": "openid-connect",
 								"protocolmapper": "oidc-usermodel-attribute-mapper",
 								"config": {
-									"user.attribute": "resourceId",
+									"user.attribute": "relatedPatients",
 									"claim.name": "patient_id",
 									"jsonType.label": "String",
 									"id.token.claim": "false",
@@ -697,7 +698,7 @@
 						"password": "change-password",
 						"passwordTemporary": false,
 						"attributes": {
-							"resourceId": ["Patient1"]
+							"relatedPatients": ["Patient1"]
 						},
 						"groups": ["fhirUser"]
 					}

--- a/keycloak-config/src/test/resources/keycloak-config.json
+++ b/keycloak-config/src/test/resources/keycloak-config.json
@@ -7,6 +7,7 @@
 		"realms": {
 			"test2": {
 				"enabled": true,
+				"unmanagedAttributePolicy": "ENABLED",
 				"clientScopes": {
 					"fhirUser": {
 						"protocol": "openid-connect",
@@ -19,7 +20,7 @@
 								"protocol": "openid-connect",
 								"protocolmapper": "oidc-patient-prefix-usermodel-attribute-mapper",
 								"config": {
-									"user.attribute": "resourceId",
+									"user.attribute": "relatedPatients",
 									"claim.name": "fhirUser",
 									"jsonType.label": "String",
 									"id.token.claim": "true",
@@ -36,16 +37,28 @@
 							"display.on.consent.screen": "false"
 						},
 						"mappers": {
-							"Patient ID Mapper": {
+							"Patient ID Claim Mapper": {
 								"protocol": "openid-connect",
 								"protocolmapper": "oidc-usermodel-attribute-mapper",
 								"config": {
-									"user.attribute": "resourceId",
+									"user.attribute": "relatedPatients",
 									"jsonType.label": "String",
-									"claim.name": "patient_id",
+									"claim.name": "patient",
 									"id.token.claim": "false",
 									"access.token.claim": "true",
 									"userinfo.token.claim": "false"
+								}
+							},
+							"Patient ID Token Mapper": {
+								"protocol": "openid-connect",
+								"protocolmapper": "oidc-usersessionmodel-note-mapper",
+								"config": {
+									"user.session.note": "patient",
+									"claim.name": "patient",
+									"jsonType.label": "String",
+									"id.token.claim": "false",
+									"access.token.claim": "false",
+									"access.tokenResponse.claim": "true"
 								}
 							},
 							"Group Membership Mapper": {

--- a/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientSelectionForm.java
+++ b/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientSelectionForm.java
@@ -67,9 +67,11 @@ public class PatientSelectionForm implements Authenticator {
 
 	private static final String SMART_SCOPE_PATIENT_READ = "patient/Patient.read";
 	private static final String SMART_SCOPE_LAUNCH_PATIENT = "launch/patient";
+	private static final String SMART_SCOPE_LAUNCH = "launch";
 
 	private static final String ATTRIBUTE_RESOURCE_ID = "relatedPatients";
 
+    private static final String SMART_PARAM_LAUNCH = "client_request_param_launch";
 
 	// creating the fhirContext is expensive, you only want to create it once
 	private static final FhirContext fhirCtx = FhirContext.forR4();
@@ -90,7 +92,7 @@ public class PatientSelectionForm implements Authenticator {
 		String requestedScopesString = authSession.getClientNote(OIDCLoginProtocol.SCOPE_PARAM);
 		Stream<ClientScopeModel> clientScopes = TokenManager.getRequestedClientScopes(requestedScopesString, client);
 
-		if (clientScopes.noneMatch(s -> SMART_SCOPE_LAUNCH_PATIENT.equals(s.getName()))) {
+		if (clientScopes.noneMatch(s -> SMART_SCOPE_LAUNCH_PATIENT.equals(s.getName()) || SMART_SCOPE_LAUNCH.equals(s.getName()))) {
 			// no launch/patient scope == no-op
 			context.success();
 			return;
@@ -106,7 +108,23 @@ public class PatientSelectionForm implements Authenticator {
 			fail(context, "Expected user to have one or more relatedPatients attributes, but found none");
 			return;
 		}
-		if (resourceIds.size() == 1) {
+
+        String requestedLaunch = getLaunchParam(context);
+        if (requestedLaunch != null) {
+            if (!requestedLaunch.isEmpty()) {
+                if (resourceIds.contains(requestedLaunch)) {
+                    LOG.debugf("Direct launch parameter; selecting patient '%s'", requestedLaunch);
+                    succeed(context, requestedLaunch);
+                    return;
+                } else {
+                    LOG.warnf("Provided launch parameter '%s' is not permitted for this user; falling back to normal selection.", requestedLaunch);
+					fail(context, "Given user isn't authorized for the provided launch parameter.");
+					return;
+                }
+            }
+        }
+
+        if (resourceIds.size() == 1) {
 			succeed(context, resourceIds.get(0));
 			return;
 		}
@@ -199,11 +217,19 @@ public class PatientSelectionForm implements Authenticator {
 		// Explicitly override the scope string with what we need (less brittle than depending on this to exist as a client scope)
 		accessToken.setScope(SMART_SCOPE_PATIENT_READ);
 
-		JsonWebToken jwt = accessToken.audience(requestedAudience);
-		// convert resource id array to a string where resource ids are separated by comma
-		jwt.setOtherClaims("patient", String.join(",",resourceIds));
-		return session.tokens().encode(jwt);
-	}
+        JsonWebToken jwt = accessToken.audience(requestedAudience);
+        // convert resource id array to a string where resource ids are separated by comma
+        String _launch = getLaunchParam(context);
+
+        if (_launch != null && !_launch.isBlank() && resourceIds.contains(_launch)) {
+            jwt.setOtherClaims("patient", _launch);
+            LOG.debugf("Setting token 'patient' claim to single id from launch: %s", _launch);
+        } else {
+            jwt.setOtherClaims("patient", String.join(",", resourceIds));
+            LOG.debugf("Setting token 'patient' claim to all assigned ids.");
+        }
+        return session.tokens().encode(jwt);
+    }
 
 	private Bundle buildRequestBundle(List<String> resourceIds) {
 
@@ -325,4 +351,33 @@ public class PatientSelectionForm implements Authenticator {
 	public void close() {
 		// nothing to do
 	}
+
+    /**
+     * Retrieves the 'launch' parameter value if present.
+     * then falls back to raw query parameter on the current HTTP request.
+     */
+    private String getLaunchParam(AuthenticationFlowContext context) {
+        try {
+            AuthenticationSessionModel authSession = context.getAuthenticationSession();
+
+            String fromNote = authSession.getClientNote(SMART_PARAM_LAUNCH);
+            if (fromNote != null && !fromNote.trim().isEmpty()) {
+                return fromNote;
+            }
+
+            if (context.getHttpRequest() != null && context.getHttpRequest().getUri() != null) {
+                MultivaluedMap<String, String> query = context.getHttpRequest().getUri().getQueryParameters();
+                if (query != null) {
+                    String fromQuery = query.getFirst("launch");
+                    if (fromQuery != null && !fromQuery.trim().isEmpty()) {
+                        return fromQuery;
+                    }
+                }
+            }
+        } catch (Throwable t) {
+            LOG.debug("Failed to retrieve launch parameter (non-fatal).", t);
+        }
+        return null;
+    }
+
 }

--- a/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientSelectionForm.java
+++ b/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientSelectionForm.java
@@ -68,7 +68,7 @@ public class PatientSelectionForm implements Authenticator {
 	private static final String SMART_SCOPE_PATIENT_READ = "patient/Patient.read";
 	private static final String SMART_SCOPE_LAUNCH_PATIENT = "launch/patient";
 
-	private static final String ATTRIBUTE_RESOURCE_ID = "resourceId";
+	private static final String ATTRIBUTE_RESOURCE_ID = "relatedPatients";
 
 
 	// creating the fhirContext is expensive, you only want to create it once
@@ -103,7 +103,7 @@ public class PatientSelectionForm implements Authenticator {
 
 		List<String> resourceIds = getResourceIdsForUser(context);
 		if (resourceIds.size() == 0) {
-			fail(context, "Expected user to have one or more resourceId attributes, but found none");
+			fail(context, "Expected user to have one or more relatedPatients attributes, but found none");
 			return;
 		}
 		if (resourceIds.size() == 1) {

--- a/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientSelectionForm.java
+++ b/keycloak-extensions/src/main/java/org/alvearie/keycloak/PatientSelectionForm.java
@@ -55,7 +55,7 @@ import static org.apache.http.HttpHeaders.AUTHORIZATION;
 
 /**
  * Present a patient context picker when the client requests the launch/patient scope and the
- * user record has multiple resourceId attributes. The selection is stored in a UserSessionNote
+ * user record has multiple relatedPatients attributes. The selection is stored in a UserSessionNote
  * with name "patient" since Firely Server expects a "patient" claim as described in
  * https://docs.fire.ly/projects/Firely-Server/en/latest/security/accesscontrol.html#tokens
  */
@@ -69,7 +69,7 @@ public class PatientSelectionForm implements Authenticator {
 	private static final String SMART_SCOPE_LAUNCH_PATIENT = "launch/patient";
 	private static final String SMART_SCOPE_LAUNCH = "launch";
 
-	private static final String ATTRIBUTE_RESOURCE_ID = "relatedPatients";
+	private static final String ATTRIBUTE_RELATED_PATIENTS = "relatedPatients";
 
     private static final String SMART_PARAM_LAUNCH = "client_request_param_launch";
 
@@ -103,8 +103,8 @@ public class PatientSelectionForm implements Authenticator {
 			return;
 		}
 
-		List<String> resourceIds = getResourceIdsForUser(context);
-		if (resourceIds.size() == 0) {
+		List<String> relatedPatients = getRelatedPatientsForUser(context);
+		if (relatedPatients.size() == 0) {
 			fail(context, "Expected user to have one or more relatedPatients attributes, but found none");
 			return;
 		}
@@ -112,7 +112,7 @@ public class PatientSelectionForm implements Authenticator {
         String requestedLaunch = getLaunchParam(context);
         if (requestedLaunch != null) {
             if (!requestedLaunch.isEmpty()) {
-                if (resourceIds.contains(requestedLaunch)) {
+                if (relatedPatients.contains(requestedLaunch)) {
                     LOG.debugf("Direct launch parameter; selecting patient '%s'", requestedLaunch);
                     succeed(context, requestedLaunch);
                     return;
@@ -124,8 +124,8 @@ public class PatientSelectionForm implements Authenticator {
             }
         }
 
-        if (resourceIds.size() == 1) {
-			succeed(context, resourceIds.get(0));
+        if (relatedPatients.size() == 1) {
+			succeed(context, relatedPatients.get(0));
 			return;
 		}
 
@@ -135,9 +135,9 @@ public class PatientSelectionForm implements Authenticator {
 			return;
 		}
 
-		String accessToken = buildInternalAccessToken(context, resourceIds);
+		String accessToken = buildInternalAccessToken(context, relatedPatients);
 
-		Bundle requestBundle = buildRequestBundle(resourceIds);
+		Bundle requestBundle = buildRequestBundle(relatedPatients);
 
 		String fhirBaseUrl = config.getConfig().get(PatientSelectionFormFactory.INTERNAL_FHIR_URL_PROP_NAME);
 		IGenericClient hapiClient = fhirCtx.newRestfulGenericClient(fhirBaseUrl);
@@ -149,7 +149,7 @@ public class PatientSelectionForm implements Authenticator {
 
 			List<PatientStruct> patients = gatherPatientInfo(returnBundle);
 			if (patients.isEmpty()) {
-				succeed(context, resourceIds.get(0));
+				succeed(context, relatedPatients.get(0));
 				return;
 			}
 
@@ -173,15 +173,15 @@ public class PatientSelectionForm implements Authenticator {
 		}
 	}
 
-	private List<String> getResourceIdsForUser(AuthenticationFlowContext context) {
-		return context.getUser().getAttributeStream(ATTRIBUTE_RESOURCE_ID)
-				.flatMap(a -> Arrays.stream(a.split(",")))
+	private List<String> getRelatedPatientsForUser(AuthenticationFlowContext context) {
+		return context.getUser().getAttributeStream(ATTRIBUTE_RELATED_PATIENTS)
+				.flatMap(a -> Arrays.stream(a.split("[,\\s]+")))
 				.map(String::trim)
 				.filter(s -> !s.isEmpty())
 				.collect(Collectors.toList());
 	}
 
-	private String buildInternalAccessToken(AuthenticationFlowContext context, List<String> resourceIds) {
+	private String buildInternalAccessToken(AuthenticationFlowContext context, List<String> relatedPatients) {
 		KeycloakSession session = context.getSession();
 		AuthenticationSessionModel authSession = context.getAuthenticationSession();
 		UserModel user = context.getUser();
@@ -218,25 +218,25 @@ public class PatientSelectionForm implements Authenticator {
 		accessToken.setScope(SMART_SCOPE_PATIENT_READ);
 
         JsonWebToken jwt = accessToken.audience(requestedAudience);
-        // convert resource id array to a string where resource ids are separated by comma
+        // convert related patients array to a string where patient ids are separated by comma
         String _launch = getLaunchParam(context);
 
-        if (_launch != null && !_launch.isBlank() && resourceIds.contains(_launch)) {
+        if (_launch != null && !_launch.isBlank() && relatedPatients.contains(_launch)) {
             jwt.setOtherClaims("patient", _launch);
             LOG.debugf("Setting token 'patient' claim to single id from launch: %s", _launch);
         } else {
-            jwt.setOtherClaims("patient", String.join(",", resourceIds));
+            jwt.setOtherClaims("patient", String.join(",", relatedPatients));
             LOG.debugf("Setting token 'patient' claim to all assigned ids.");
         }
         return session.tokens().encode(jwt);
     }
 
-	private Bundle buildRequestBundle(List<String> resourceIds) {
+	private Bundle buildRequestBundle(List<String> relatedPatients) {
 
 		Bundle searchBundle = new Bundle();
 		searchBundle.setType(BundleType.BATCH);
 
-		for (String id : resourceIds) {
+		for (String id : relatedPatients) {
 			BundleEntryComponent bec = searchBundle.addEntry();
 			BundleEntryRequestComponent request = new BundleEntryRequestComponent();
 			request.setMethod(HTTPVerb.GET);
@@ -335,7 +335,7 @@ public class PatientSelectionForm implements Authenticator {
 
 		LOG.debugf("The user selected patient '%s'", patient);
 
-		if (patient == null || patient.trim().isEmpty() || !getResourceIdsForUser(context).contains(patient.trim())) {
+		if (patient == null || patient.trim().isEmpty() || !getRelatedPatientsForUser(context).contains(patient.trim())) {
 			LOG.warnf("The patient selection '%s' is not valid for the authenticated user.", patient);
 			context.cancelLogin();
 

--- a/keycloak-extensions/src/test/java/org/alvearie/keycloak/KeycloakContainerTest.java
+++ b/keycloak-extensions/src/test/java/org/alvearie/keycloak/KeycloakContainerTest.java
@@ -39,10 +39,10 @@ import okhttp3.mockwebserver.RecordedRequest;
 public class KeycloakContainerTest {
 	private static final String MASTER_REALM = "master";
 	private static final String ADMIN_CLIENT_ID = "admin-cli";
-	private static final String USERNAME = "a";
-	private static final String PASSWORD = "a";
+	private static final String USERNAME = "testa";
+	private static final String PASSWORD = "testa";
 	private static final String KC_CLIENT = "test";
-	private static final String REDIRECT_URI = "http://localhost";
+	private static final String REDIRECT_URI = "http://localhost:19876/callback";
 	private static final String AUTH_ENDPOINT = "/realms/test/protocol/openid-connect/auth";
 	private static final String TOKEN_ENDPOINT = "/realms/test/protocol/openid-connect/token";
 	private static final String AUDIENCE = "https://localhost:9443/fhir-server/api/v4";
@@ -60,7 +60,7 @@ public class KeycloakContainerTest {
 	// per the testcontainers doc, the contain should be started in a static block before JUnit starts up
 	private static KeycloakContainer keycloak;
 	static {
-		keycloak = new KeycloakContainer("quay.io/keycloak/keycloak:22.0.1").withProviderClassesFrom("target/classes")
+		keycloak = new KeycloakContainer("quay.io/keycloak/keycloak:25.0.5").withProviderClassesFrom("target/classes")
 				.withFileSystemBind("target/dependency", "/opt/keycloak/providers/");
 		keycloak.withEnv("DB_VENDOR", "H2");
 		// Uncomment this to keep the container running after the tests complete
@@ -151,7 +151,7 @@ public class KeycloakContainerTest {
 		String[] accessTokenParts = accessToken.split("\\.");
 		assertEquals(3, accessTokenParts.length);
 		Map<?,?> claims = new ObjectMapper().readValue(Base64.getDecoder().decode(accessTokenParts[1]), HashMap.class);
-		assertTrue(claims.containsKey("patient_id"));
-		System.out.println("patient_id claim: " + claims.get("patient_id"));
+		assertTrue(claims.containsKey("patient"));
+		System.out.println("patient claim: " + claims.get("patient"));
 	}
 }

--- a/keycloak-extensions/src/test/java/org/alvearie/utils/SeleniumOauthInteraction.java
+++ b/keycloak-extensions/src/test/java/org/alvearie/utils/SeleniumOauthInteraction.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.fail;
 
 import java.net.URI;
 import java.net.URLDecoder;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -56,7 +57,9 @@ public class SeleniumOauthInteraction {
 
 		WebDriverManager.chromedriver().setup();
 		ChromeOptions options = new ChromeOptions();
-		options.setHeadless(true);
+		options.addArguments("--headless=new");
+		options.addArguments("--disable-gpu");
+		options.addArguments("--no-sandbox");
 		driver = new ChromeDriver(options);
 	}
 
@@ -89,14 +92,14 @@ public class SeleniumOauthInteraction {
 			// launch Firefox and direct it to the Base URL
 			driver.get(oauthAuthUrl + "?" + queryString);
 
-			WebElement dynamicElement = (new WebDriverWait(driver, 30))
+			WebElement dynamicElement = (new WebDriverWait(driver, Duration.ofSeconds(30)))
 					.until(ExpectedConditions.presenceOfElementLocated(By.id("username")));
 			dynamicElement.sendKeys(user);
 
 			driver.findElement(By.id("password")).sendKeys(pass);
 			driver.findElement(By.id("kc-login")).click();
 
-			Boolean loginButtonDisappeared = (new WebDriverWait(driver, 5, 200))
+			Boolean loginButtonDisappeared = (new WebDriverWait(driver, Duration.ofSeconds(5), Duration.ofMillis(200)))
 					.until(ExpectedConditions.invisibilityOfElementLocated(By.id("kc-login")));
 			LOGGER.debug("Login button is visible?? " + !loginButtonDisappeared);
 
@@ -113,11 +116,11 @@ public class SeleniumOauthInteraction {
 			//   header.div kc-username
 			//   div kc-content
 			//   form id=patient-selection
-			//   input id=<patient_id> (one per patient that the user has access to)
+			//   input id=<patient> (one per patient that the user has access to)
 			//   input id=submit
 			try {
 				// wait up to 3 seconds - poll for element every 200 ms
-				new WebDriverWait(driver, 5, 200)
+				new WebDriverWait(driver, Duration.ofSeconds(5), Duration.ofMillis(200))
 				.until(ExpectedConditions.presenceOfElementLocated(By.id("patient-selection")));
 
 				// simulate choosing the patient that has an id of "PatientA"
@@ -127,24 +130,6 @@ public class SeleniumOauthInteraction {
 			} catch ( TimeoutException e ) {
 				LOGGER.error("Expected the patient selection form but didn't find it", e);
 				fail("Expected the patient selection form but didn't find it");
-			}
-
-			// wait up to 2 seconds for screen showing YES/NO page for first-time users.
-			// Page contents:
-			//   kc-page-title=Grant Access to inferno
-			//   li - permissions granted
-			//   input id=kc-cancel NO
-			//   input kd=kc-login YES
-			try {
-				// either the button is found or a TimeoutException is generated
-				WebElement grantAccessButton = (new WebDriverWait(driver, 1,200))
-						.until(ExpectedConditions.presenceOfElementLocated(By.id("kc-login")));
-
-				grantAccessButton.click();
-			} catch ( TimeoutException e ) {
-				// Didn't find YES button with id='kc-login'.
-				// Ignore exception; probably not the first sign-on for this user.
-				LOGGER.error("Didn't find YES button with id='kc-login' - ignore exception" + e.getMessage());
 			}
 
 			// poll at 500 ms interval until 'code' is present in URL query parameter list.
@@ -251,7 +236,7 @@ public class SeleniumOauthInteraction {
 		SeleniumOauthInteraction s = new SeleniumOauthInteraction("test", "https://localhost",
 				baseUrl + "auth", baseUrl + "token");
 
-		Map<String, String> authResponse = s.fetchCode("a", "a", "https://localhost:9443/fhir-server/api/v4",
+		Map<String, String> authResponse = s.fetchCode("testa", "testa", "https://localhost:9443/fhir-server/api/v4",
 				"openid", "launch/patient");
 		Map<String, String> tokenResponse = s.fetchToken(authResponse.get("code"));
 

--- a/keycloak-extensions/src/test/resources/keycloak-config.json
+++ b/keycloak-extensions/src/test/resources/keycloak-config.json
@@ -1,6 +1,7 @@
 {
 	"test": {
 		"enabled": true,
+		"unmanagedAttributePolicy": "ENABLED",
 		"clientScopes": {
 			"fhirUser": {
 				"protocol": "openid-connect",
@@ -13,7 +14,7 @@
 						"protocol": "openid-connect",
 						"protocolmapper": "oidc-patient-prefix-usermodel-attribute-mapper",
 						"config": {
-							"user.attribute": "resourceId",
+							"user.attribute": "relatedPatients",
 							"claim.name": "fhirUser",
 							"jsonType.label": "String",
 							"id.token.claim": "true",
@@ -34,8 +35,8 @@
 						"protocol": "openid-connect",
 						"protocolmapper": "oidc-usermodel-attribute-mapper",
 						"config": {
-							"user.attribute": "resourceId",
-							"claim.name": "patient_id",
+							"user.attribute": "relatedPatients",
+							"claim.name": "patient",
 							"jsonType.label": "String",
 							"id.token.claim": "false",
 							"access.token.claim": "true",
@@ -46,7 +47,7 @@
 						"protocol": "openid-connect",
 						"protocolmapper": "oidc-usersessionmodel-note-mapper",
 						"config": {
-							"user.session.note": "patient_id",
+							"user.session.note": "patient",
 							"claim.name": "patient",
 							"jsonType.label": "String",
 							"id.token.claim": "false",
@@ -112,10 +113,9 @@
 			}
 		},
 		"browserFlow": "SMART App Launch",
-		"defaultDefaultClientScopes": ["profile"],
+		"defaultDefaultClientScopes": ["profile", "launch/patient"],
 		"defaultOptionalClientScopes": [
-			"fhirUser",
-			"launch/patient"
+			"fhirUser"
 		],
 		"clients": {
 			"test": {
@@ -124,24 +124,24 @@
 				"bearerOnly": false,
 				"enableDirectAccess": true,
 				"rootURL": "http://localhost",
-				"redirectURIs": ["http://localhost/*"]
+				"redirectURIs": ["http://localhost:19876/*"]
 			}
 		},
 		"users": {
-			"a": {
+			"testa": {
 				"enabled": true,
-				"password": "a",
+				"password": "testa",
 				"passwordTemporary": false,
 				"attributes": {
-					"resourceId": ["PatientA PatientB PatientMissing"]
+					"relatedPatients": ["PatientA PatientB PatientMissing"]
 				}
 			},
-			"b": {
+			"testb": {
 				"enabled": true,
-				"password": "b",
+				"password": "testb",
 				"passwordTemporary": false,
 				"attributes": {
-					"resourceId": ["PatientB"]
+					"relatedPatients": ["PatientB"]
 				}
 			}
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 
   <properties>
     <keycloak.version>25.0.5</keycloak.version>
-    <!-- 1.10.0 = 17.0.0-legacy  2.2.2=18.0.0 -->
-    <testcontainers-keycloak.version>2.2.2</testcontainers-keycloak.version>
+    <!-- 3.4.0 supports Keycloak 22+ -->
+    <testcontainers-keycloak.version>3.4.0</testcontainers-keycloak.version>
     <hapi.fhir.version>5.7.2</hapi.fhir.version>
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -114,13 +114,13 @@
       <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-java</artifactId>
-        <version>4.1.1</version>
+        <version>4.27.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.github.bonigarcia</groupId>
         <artifactId>webdrivermanager</artifactId>
-        <version>5.3.1</version>
+        <version>5.9.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/setup/SETUP.md
+++ b/setup/SETUP.md
@@ -1,0 +1,116 @@
+# Local Setup and Testing Guide
+
+## Prerequisites
+
+- Docker installed and running
+
+## Quick Start
+
+The workflow uses multiple scripts, which can be run individually in an order as specified below.
+
+### 1. Build the images
+
+There are two separate build scripts per each section of the project.
+
+**Build the Keycloak server image** (only needed when the source code changes):
+
+```bash
+./setup/build-keycloak.sh
+```
+
+Produces **alvearie/smart-keycloak:25.0.5** — Keycloak 25 with the custom SMART authenticators and protocol mappers installed as a provider JAR.
+
+**Build the config tool image** (needed when configuration files or the source code changes):
+
+```bash
+./setup/build-config.sh
+```
+
+Produces **alvearie/smart-keycloak-config:25.0.5** — a standalone CLI that provisions a Keycloak realm with all SMART on FHIR scopes, mappers, flows, and test users.
+
+The if a configuration change is made only, the original building task for Smart Keycloak can be skipped as this script takes less time than re-building the entire pipeline.
+
+### 2. Start Keycloak
+
+```bash
+./setup/start.sh
+```
+
+This creates a Docker network (`smart-kc-net`), then starts a Keycloak container in development mode on `http://localhost:8080`. The script is safe to re-run as it removes any leftover containers and networks from a previous session first.
+
+Before moving on with the final script, wait until Keycloak can respond to:
+
+```bash
+curl -sf http://localhost:8080/realms/master
+```
+
+### 3. Configure the realm
+
+```bash
+./setup/configure.sh
+```
+
+This runs the config tool on the Smart Keycloak instance and sets up a realm with respect to the Keycloak Config configurations.
+On default, the created realm is called `test`, containing:
+
+- All SMART on FHIR client scopes (`launch/patient`, `fhirUser`, `patient/*.read`, individual resource scopes etc.) with the appropriate audience and claim mappers
+- The **inferno** public test client
+- A **SMART App Launch** browser authentication flow with audience validation and patient selection steps
+- A test user: **fhiruser** / **change-password**, with the `relatedPatients` attribute set to `Patient1`
+- The User Profile `unmanagedAttributePolicy` set to `ENABLED`, so that custom attributes like `relatedPatients` are visible and editable in the admin console without extra configuration
+
+## Verification
+
+Once `configure.sh` completes, final verification can be conducted through:
+
+### Admin console
+
+Open `http://localhost:8080/admin` and log in with `admin` / `admin`. Navigate to the `test` realm, then check Users > fhiruser > Attributes to confirm the `relatedPatients` attribute is present.
+
+### OIDC discovery endpoint
+
+```bash
+curl -s http://localhost:8080/realms/test/.well-known/openid-configuration | python -m json.tool
+```
+
+This should return a complete OIDC discovery document for the `test` realm. If it contains the SMART scopes as needed, the setup is most likely successful. However, further verifications are still helpful.
+
+### SMART App Launch flow (browser)
+
+Paste this URL into a browser to start an authorization request as the `inferno` client:
+
+```
+http://localhost:8080/realms/test/protocol/openid-connect/auth?client_id=inferno&response_type=code&scope=openid%20fhirUser%20launch/patient%20patient/*.read&redirect_uri=http://localhost:4567/inferno/callback&aud=https://localhost:9443/fhir-server/api/v4
+```
+
+Log in with `fhiruser` / `change-password`. If the authentication flow completes (consent screen or redirect), the extensions and configuration are working together correctly.
+
+Note: The redirect will fail if Inferno client isn't set, however, it is not needed as long as the response returns a "code=..." field to provide the auth code that can be used in a request as given below to retrieve the final Access Token:
+
+```bash
+curl -s -X POST http://localhost:8080/realms/test/protocol/openid-connect/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=authorization_code" \
+  -d "code=<auth_code>" \
+  -d "redirect_uri=http://localhost:4567/inferno/callback" \
+  -d "client_id=inferno"
+```
+
+Replace `<auth_code>` with the value of the `code` parameter from the redirect URL. A successful response will include an `access_token`, `token_type`, and a `patient` field in the token response body confirming the patient context was resolved correctly.
+
+## Customisation
+
+All four scripts accept environment variables to override defaults. Certain deployment values from before are only set as examples.
+
+## Cleanup
+
+To stop the Keycloak container and remove the Docker network:
+
+```bash
+docker rm -f smart-kc-test && docker network rm smart-kc-net
+```
+
+## Post-Config
+
+After the initial configuration of Keycloak, the base SMART Keycloak image and the test realm can be edited and reused by exporting and re-importing the said components.
+Alternatively, Keycloak-Config can be edited by itself to initialize a realm of desired specs from scratch.

--- a/setup/build-config.sh
+++ b/setup/build-config.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# build-config.sh - Build the realm configuration tool image
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+KC_CONFIG_IMAGE="alvearie/smart-keycloak-config:25.0.5"
+
+echo "==> Building config tool image: $KC_CONFIG_IMAGE"
+docker build -t "$KC_CONFIG_IMAGE" -f "$PROJECT_DIR/keycloak-config/Dockerfile" "$PROJECT_DIR"
+
+echo ""
+echo "Done. Image ready: $KC_CONFIG_IMAGE"

--- a/setup/build-keycloak.sh
+++ b/setup/build-keycloak.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# build-keycloak.sh - Build the Keycloak server image
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+KC_IMAGE="alvearie/smart-keycloak:25.0.5"
+
+echo "==> Building Keycloak image: $KC_IMAGE"
+docker build -t "$KC_IMAGE" -f "$PROJECT_DIR/Dockerfile" "$PROJECT_DIR"
+
+echo ""
+echo "Done. Image ready: $KC_IMAGE"

--- a/setup/configure.sh
+++ b/setup/configure.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# configure.sh - Provision a SMART on FHIR realm on a running Keycloak
+set -euo pipefail
+
+KC_CONFIG_IMAGE="${KC_CONFIG_IMAGE:-alvearie/smart-keycloak-config:25.0.5}"
+KC_CONFIG_CONTAINER="smart-kc-config-test"
+KC_CONTAINER="smart-kc-test"
+NETWORK="smart-kc-net"
+
+KC_ADMIN_USER="${KC_ADMIN_USER:-admin}"
+KC_ADMIN_PASS="${KC_ADMIN_PASS:-admin}"
+KC_PORT="${KC_PORT:-8080}"
+KC_REALM="${KC_REALM:-test}"
+FHIR_BASE_URL="${FHIR_BASE_URL:-https://localhost:9443/fhir-server/api/v4}"
+
+echo "==> Provisioning realm '${KC_REALM}' ..."
+
+docker run --rm \
+  --name "$KC_CONFIG_CONTAINER" \
+  --network "$NETWORK" \
+  -e KEYCLOAK_BASE_URL="http://${KC_CONTAINER}:8080" \
+  -e KEYCLOAK_REALM="$KC_REALM" \
+  -e KEYCLOAK_USER="$KC_ADMIN_USER" \
+  -e KEYCLOAK_PASSWORD="$KC_ADMIN_PASS" \
+  -e FHIR_BASE_URL="$FHIR_BASE_URL" \
+  "$KC_CONFIG_IMAGE" \
+  -configFile config/keycloak-config.json
+
+echo ""
+echo " Realm '${KC_REALM}' is ready."
+echo ""
+echo " Admin console : http://localhost:${KC_PORT}/admin"
+echo "                  user: ${KC_ADMIN_USER} / pass: ${KC_ADMIN_PASS}"
+echo ""
+echo " OIDC discovery: http://localhost:${KC_PORT}/realms/${KC_REALM}/.well-known/openid-configuration"
+echo ""
+echo " Test login (paste in browser):"
+echo "   http://localhost:${KC_PORT}/realms/${KC_REALM}/protocol/openid-connect/auth?client_id=inferno&response_type=code&scope=openid%20fhirUser%20launch/patient%20patient/*.read&redirect_uri=http://localhost:4567/inferno/callback&aud=${FHIR_BASE_URL}"
+echo ""
+echo " Login with: fhiruser / change-password (if not changed through keycloak-config configurations)"

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# start.sh - Start a Keycloak container from the alvearie/smart-keycloak image
+set -euo pipefail
+
+KC_IMAGE="${KC_IMAGE:-alvearie/smart-keycloak:25.0.5}"
+KC_CONTAINER="smart-kc-test"
+NETWORK="smart-kc-net"
+
+KC_ADMIN_USER="${KC_ADMIN_USER:-admin}"
+KC_ADMIN_PASS="${KC_ADMIN_PASS:-admin}"
+KC_PORT="${KC_PORT:-8080}"
+
+# Clean
+echo "==> Removing previous container and network if exists..."
+docker rm -f "$KC_CONTAINER" 2>/dev/null || true
+docker network rm "$NETWORK" 2>/dev/null || true
+
+# Network
+echo "==> Creating Docker network: $NETWORK"
+docker network create "$NETWORK"
+
+# Keycloak
+echo "==> Starting Keycloak container: $KC_CONTAINER"
+docker run -d \
+  --name "$KC_CONTAINER" \
+  --network "$NETWORK" \
+  -p "${KC_PORT}:8080" \
+  -e KC_HEALTH_ENABLED=true \
+  -e KEYCLOAK_ADMIN="$KC_ADMIN_USER" \
+  -e KEYCLOAK_ADMIN_PASSWORD="$KC_ADMIN_PASS" \
+  "$KC_IMAGE"
+
+echo ""
+echo "Keycloak is booting up on http://localhost:${KC_PORT}"
+echo "Wait until it is ready, then run ./configure.sh to provision the realm."


### PR DESCRIPTION
- CDR Launch Scope and related Mappers are updated to use "relatedPatients" instead of "resourceId" on both keycloak-config and the main extension.
- Unmanaged Attributes' activation options are implemented as it is deactivated by default on Keycloak 25.0.5
- Setup steps for both keycloak-config and the extension are simplified under four scripts, alongside a simplified SETUP.md which provides steps of deployment and verification.